### PR TITLE
add local search

### DIFF
--- a/knowledge-base/docusaurus.config.js
+++ b/knowledge-base/docusaurus.config.js
@@ -19,7 +19,14 @@ const config = {
     defaultLocale: 'en',
     locales: ['en'],
   },
-  plugins: [require.resolve("@cmfcmf/docusaurus-search-local")],
+  plugins: [
+    [
+      require.resolve("@cmfcmf/docusaurus-search-local"),
+      {
+        indexBlog: false,
+      }
+    ]
+  ],
   scripts: [
     {
       src: 'https://unpkg.com/@tinybirdco/flock.js',

--- a/knowledge-base/docusaurus.config.js
+++ b/knowledge-base/docusaurus.config.js
@@ -19,6 +19,7 @@ const config = {
     defaultLocale: 'en',
     locales: ['en'],
   },
+  plugins: [require.resolve("@cmfcmf/docusaurus-search-local")],
   scripts: [
     {
       src: 'https://unpkg.com/@tinybirdco/flock.js',

--- a/knowledge-base/package-lock.json
+++ b/knowledge-base/package-lock.json
@@ -8,6 +8,7 @@
       "name": "clickhouse-knowledge-base",
       "version": "0.0.0",
       "dependencies": {
+        "@cmfcmf/docusaurus-search-local": "^0.11.0",
         "@docusaurus/core": "2.1.0",
         "@docusaurus/preset-classic": "2.1.0",
         "@mdx-js/react": "^1.6.22",
@@ -33,6 +34,46 @@
         "@algolia/autocomplete-shared": "1.7.1"
       }
     },
+    "node_modules/@algolia/autocomplete-js": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-js/-/autocomplete-js-1.7.2.tgz",
+      "integrity": "sha512-/x0r0510yEHtTt9+JIhWa9CIvS2s95n5eSyKrCXA6QF8DYKJV+LQpGCpHnO4gEHJFEe0itVdmws3DzOZrBGa9Q==",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.7.2",
+        "@algolia/autocomplete-preset-algolia": "1.7.2",
+        "@algolia/autocomplete-shared": "1.7.2",
+        "htm": "^3.0.0",
+        "preact": "^10.0.0"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.5.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-js/node_modules/@algolia/autocomplete-core": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.2.tgz",
+      "integrity": "sha512-eclwUDC6qfApNnEfu1uWcL/rudQsn59tjEoUYZYE2JSXZrHLRjBUGMxiCoknobU2Pva8ejb0eRxpIYDtVVqdsw==",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.7.2"
+      }
+    },
+    "node_modules/@algolia/autocomplete-js/node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.2.tgz",
+      "integrity": "sha512-+RYEG6B0QiGGfRb2G3MtPfyrl0dALF3cQNTWBzBX6p5o01vCCGTTinAm2UKG3tfc2CnOMAtnPLkzNZyJUpnVJw==",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.7.2"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-js/node_modules/@algolia/autocomplete-shared": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.2.tgz",
+      "integrity": "sha512-QCckjiC7xXHIUaIL3ektBtjJ0w7tTA3iqKcAE/Hjn1lZ5omp7i3Y4e09rAr9ZybqirL7AbxCLLq0Ra5DDPKeug=="
+    },
     "node_modules/@algolia/autocomplete-preset-algolia": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.1.tgz",
@@ -49,6 +90,11 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.1.tgz",
       "integrity": "sha512-eTmGVqY3GeyBTT8IWiB2K5EuURAqhnumfktAEoHxfDY2o7vg2rSnO16ZtIG0fMgt3py28Vwgq42/bVEuaQV7pg=="
+    },
+    "node_modules/@algolia/autocomplete-theme-classic": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-theme-classic/-/autocomplete-theme-classic-1.7.2.tgz",
+      "integrity": "sha512-bUoT4wdScyAY4oZrk3zcaGwSKYJ11MGXNFIckWWN/Bd9xqoFu8/09Ujyw5WyzYZidHrs8D3FSTJi6sfHz5g3/Q=="
     },
     "node_modules/@algolia/cache-browser-local-storage": {
       "version": "4.14.2",
@@ -1953,6 +1999,30 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cmfcmf/docusaurus-search-local": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@cmfcmf/docusaurus-search-local/-/docusaurus-search-local-0.11.0.tgz",
+      "integrity": "sha512-UzJ0G7JfrhuXJ9h79vforQZs05C5rWhXqrK7C5ie1ImHLTC4RPW7FHagIpZULhcA2PbDkc4ewnWVIufLKq+KzA==",
+      "dependencies": {
+        "@algolia/autocomplete-js": "^1.5.1",
+        "@algolia/autocomplete-theme-classic": "^1.5.1",
+        "@algolia/client-search": "^4.12.0",
+        "algoliasearch": "^4.12.0",
+        "cheerio": "^1.0.0-rc.9",
+        "clsx": "^1.1.1",
+        "lunr-languages": "^1.4.0",
+        "mark.js": "^8.11.1"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^v2.0.0-beta.21",
+        "nodejieba": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "nodejieba": {
+          "optional": true
+        }
       }
     },
     "node_modules/@colors/colors": {
@@ -6639,6 +6709,11 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/htm": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ=="
+    },
     "node_modules/html-entities": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
@@ -7542,6 +7617,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/lunr-languages": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/lunr-languages/-/lunr-languages-1.10.0.tgz",
+      "integrity": "sha512-BBjKKcwrieJlzwwc9M5H/MRXGJ2qyOSDx/NXYiwkuKjiLOOoouh0WsDzeqcLoUWcX31y7i8sb8IgsZKObdUCkw=="
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -7563,6 +7643,11 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ=="
     },
     "node_modules/markdown-escapes": {
       "version": "1.0.4",
@@ -8980,6 +9065,15 @@
       },
       "peerDependencies": {
         "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.11.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.2.tgz",
+      "integrity": "sha512-skAwGDFmgxhq1DCBHke/9e12ewkhc7WYwjuhHB8HHS8zkdtITXLRmUMTeol2ldxvLwYtwbFeifZ9uDDWuyL4Iw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/prepend-http": {
@@ -12347,6 +12441,41 @@
         "@algolia/autocomplete-shared": "1.7.1"
       }
     },
+    "@algolia/autocomplete-js": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-js/-/autocomplete-js-1.7.2.tgz",
+      "integrity": "sha512-/x0r0510yEHtTt9+JIhWa9CIvS2s95n5eSyKrCXA6QF8DYKJV+LQpGCpHnO4gEHJFEe0itVdmws3DzOZrBGa9Q==",
+      "requires": {
+        "@algolia/autocomplete-core": "1.7.2",
+        "@algolia/autocomplete-preset-algolia": "1.7.2",
+        "@algolia/autocomplete-shared": "1.7.2",
+        "htm": "^3.0.0",
+        "preact": "^10.0.0"
+      },
+      "dependencies": {
+        "@algolia/autocomplete-core": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.2.tgz",
+          "integrity": "sha512-eclwUDC6qfApNnEfu1uWcL/rudQsn59tjEoUYZYE2JSXZrHLRjBUGMxiCoknobU2Pva8ejb0eRxpIYDtVVqdsw==",
+          "requires": {
+            "@algolia/autocomplete-shared": "1.7.2"
+          }
+        },
+        "@algolia/autocomplete-preset-algolia": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.2.tgz",
+          "integrity": "sha512-+RYEG6B0QiGGfRb2G3MtPfyrl0dALF3cQNTWBzBX6p5o01vCCGTTinAm2UKG3tfc2CnOMAtnPLkzNZyJUpnVJw==",
+          "requires": {
+            "@algolia/autocomplete-shared": "1.7.2"
+          }
+        },
+        "@algolia/autocomplete-shared": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.2.tgz",
+          "integrity": "sha512-QCckjiC7xXHIUaIL3ektBtjJ0w7tTA3iqKcAE/Hjn1lZ5omp7i3Y4e09rAr9ZybqirL7AbxCLLq0Ra5DDPKeug=="
+        }
+      }
+    },
     "@algolia/autocomplete-preset-algolia": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.1.tgz",
@@ -12359,6 +12488,11 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.1.tgz",
       "integrity": "sha512-eTmGVqY3GeyBTT8IWiB2K5EuURAqhnumfktAEoHxfDY2o7vg2rSnO16ZtIG0fMgt3py28Vwgq42/bVEuaQV7pg=="
+    },
+    "@algolia/autocomplete-theme-classic": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-theme-classic/-/autocomplete-theme-classic-1.7.2.tgz",
+      "integrity": "sha512-bUoT4wdScyAY4oZrk3zcaGwSKYJ11MGXNFIckWWN/Bd9xqoFu8/09Ujyw5WyzYZidHrs8D3FSTJi6sfHz5g3/Q=="
     },
     "@algolia/cache-browser-local-storage": {
       "version": "4.14.2",
@@ -13688,6 +13822,21 @@
         "@babel/helper-string-parser": "^7.18.10",
         "@babel/helper-validator-identifier": "^7.18.6",
         "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@cmfcmf/docusaurus-search-local": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@cmfcmf/docusaurus-search-local/-/docusaurus-search-local-0.11.0.tgz",
+      "integrity": "sha512-UzJ0G7JfrhuXJ9h79vforQZs05C5rWhXqrK7C5ie1ImHLTC4RPW7FHagIpZULhcA2PbDkc4ewnWVIufLKq+KzA==",
+      "requires": {
+        "@algolia/autocomplete-js": "^1.5.1",
+        "@algolia/autocomplete-theme-classic": "^1.5.1",
+        "@algolia/client-search": "^4.12.0",
+        "algoliasearch": "^4.12.0",
+        "cheerio": "^1.0.0-rc.9",
+        "clsx": "^1.1.1",
+        "lunr-languages": "^1.4.0",
+        "mark.js": "^8.11.1"
       }
     },
     "@colors/colors": {
@@ -17171,6 +17320,11 @@
         }
       }
     },
+    "htm": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ=="
+    },
     "html-entities": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
@@ -17792,6 +17946,11 @@
         "yallist": "^4.0.0"
       }
     },
+    "lunr-languages": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/lunr-languages/-/lunr-languages-1.10.0.tgz",
+      "integrity": "sha512-BBjKKcwrieJlzwwc9M5H/MRXGJ2qyOSDx/NXYiwkuKjiLOOoouh0WsDzeqcLoUWcX31y7i8sb8IgsZKObdUCkw=="
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -17806,6 +17965,11 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
+    },
+    "mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ=="
     },
     "markdown-escapes": {
       "version": "1.0.4",
@@ -18742,6 +18906,11 @@
       "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-5.1.0.tgz",
       "integrity": "sha512-fgFMf0OtVSBR1va1JNHYgMxYk73yhn/qb4uQDq1DLGYolz8gHCyr/sesEuGUaYs58E3ZJRcpoGuPVoB7Meiq9A==",
       "requires": {}
+    },
+    "preact": {
+      "version": "10.11.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.2.tgz",
+      "integrity": "sha512-skAwGDFmgxhq1DCBHke/9e12ewkhc7WYwjuhHB8HHS8zkdtITXLRmUMTeol2ldxvLwYtwbFeifZ9uDDWuyL4Iw=="
     },
     "prepend-http": {
       "version": "2.0.0",

--- a/knowledge-base/package.json
+++ b/knowledge-base/package.json
@@ -15,6 +15,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
+    "@cmfcmf/docusaurus-search-local": "^0.11.0",
     "@docusaurus/core": "2.1.0",
     "@docusaurus/preset-classic": "2.1.0",
     "@mdx-js/react": "^1.6.22",


### PR DESCRIPTION
This PR adds the @cmfcmf/docusaurus-search-local plugin which creates a local search index. I've appleid for Algolia DocSearch, but we are waiting on a response, so this will work in the meantime.