### PR TITLE
Fix duplicated base path in root url

### DIFF
--- a/knowledge-base/docusaurus.config.js
+++ b/knowledge-base/docusaurus.config.js
@@ -9,6 +9,7 @@ const config = {
   title: 'ClickHouse Knowledge Base',
   tagline: 'with love from Tinybird',
   url: 'https://tinybird.co',
+  trailingSlash: false,
   baseUrl: '/clickhouse/knowledge-base/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'throw',


### PR DESCRIPTION
There's an error in the [root base path ](https://www.tinybird.co/clickhouse/knowledge-base/) that makes the path to appears twice in the hreflang tags. This only affects these tags, everything else works fine.

It seems that if we set the `trailingSlash` property on docusaurus config to false the problem is solved. So I've applied this change in this commit to fix this.

More info about this problem can be found here:
https://github.com/facebook/docusaurus/issues/6315