### PR TITLE
Revert "Fix duplicated base path in root url (#20)"

### DIFF
--- a/knowledge-base/docusaurus.config.js
+++ b/knowledge-base/docusaurus.config.js
@@ -9,7 +9,6 @@ const config = {
   title: 'ClickHouse Knowledge Base',
   tagline: 'with love from Tinybird',
   url: 'https://tinybird.co',
-  trailingSlash: false,
   baseUrl: '/clickhouse/knowledge-base/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'throw',


### PR DESCRIPTION
This reverts commit 495e0765b0211bab381e361b17d0c322d11059ca due that it causes 404 errors on production. It seems that something doesn't work as expected when it's used with our current proxy pass.