### PR TITLE
Prevent indexation of categories and tags pages

### DIFF
--- a/knowledge-base/src/theme/DocCategoryGeneratedIndexPage/index.js
+++ b/knowledge-base/src/theme/DocCategoryGeneratedIndexPage/index.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import {
+  PageMetadata,
+  useCurrentSidebarCategory,
+} from '@docusaurus/theme-common';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import DocCardList from '@theme/DocCardList';
+import DocPaginator from '@theme/DocPaginator';
+import DocVersionBanner from '@theme/DocVersionBanner';
+import DocVersionBadge from '@theme/DocVersionBadge';
+import DocBreadcrumbs from '@theme/DocBreadcrumbs';
+import Heading from '@theme/Heading';
+import styles from './styles.module.css';
+function DocCategoryGeneratedIndexPageMetadata({categoryGeneratedIndex}) {
+  return (
+    <PageMetadata
+      title={categoryGeneratedIndex.title}
+      description={categoryGeneratedIndex.description}
+      keywords={categoryGeneratedIndex.keywords}
+      // TODO `require` this?
+      image={useBaseUrl(categoryGeneratedIndex.image)}
+    >
+      <meta name="robots" content="noindex, nofollow" />
+    </PageMetadata>
+  );
+}
+function DocCategoryGeneratedIndexPageContent({categoryGeneratedIndex}) {
+  const category = useCurrentSidebarCategory();
+  return (
+    <div className={styles.generatedIndexPage}>
+      <DocVersionBanner />
+      <DocBreadcrumbs />
+      <DocVersionBadge />
+      <header>
+        <Heading as="h1" className={styles.title}>
+          {categoryGeneratedIndex.title}
+        </Heading>
+        {categoryGeneratedIndex.description && (
+          <p>{categoryGeneratedIndex.description}</p>
+        )}
+      </header>
+      <article className="margin-top--lg">
+        <DocCardList items={category.items} className={styles.list} />
+      </article>
+      <footer className="margin-top--lg">
+        <DocPaginator
+          previous={categoryGeneratedIndex.navigation.previous}
+          next={categoryGeneratedIndex.navigation.next}
+        />
+      </footer>
+    </div>
+  );
+}
+export default function DocCategoryGeneratedIndexPage(props) {
+  return (
+    <>
+      <DocCategoryGeneratedIndexPageMetadata {...props} />
+      <DocCategoryGeneratedIndexPageContent {...props} />
+    </>
+  );
+}

--- a/knowledge-base/src/theme/DocCategoryGeneratedIndexPage/styles.module.css
+++ b/knowledge-base/src/theme/DocCategoryGeneratedIndexPage/styles.module.css
@@ -1,0 +1,19 @@
+@media (min-width: 997px) {
+  .generatedIndexPage {
+    max-width: 75% !important;
+  }
+
+  .list article:nth-last-child(-n + 2) {
+    margin-bottom: 0 !important;
+  }
+}
+
+/* Duplicated from .markdown h1 */
+.title {
+  --ifm-h1-font-size: 3rem;
+  margin-bottom: calc(1.25 * var(--ifm-leading));
+}
+
+.list article:last-child {
+  margin-bottom: 0 !important;
+}

--- a/knowledge-base/src/theme/DocTagDocListPage/index.js
+++ b/knowledge-base/src/theme/DocTagDocListPage/index.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import clsx from 'clsx';
+import Link from '@docusaurus/Link';
+import {
+  PageMetadata,
+  HtmlClassNameProvider,
+  ThemeClassNames,
+  usePluralForm,
+} from '@docusaurus/theme-common';
+import Translate, {translate} from '@docusaurus/Translate';
+import Layout from '@theme/Layout';
+import SearchMetadata from '@theme/SearchMetadata';
+// Very simple pluralization: probably good enough for now
+function useNDocsTaggedPlural() {
+  const {selectMessage} = usePluralForm();
+  return (count) =>
+    selectMessage(
+      count,
+      translate(
+        {
+          id: 'theme.docs.tagDocListPageTitle.nDocsTagged',
+          description:
+            'Pluralized label for "{count} docs tagged". Use as much plural forms (separated by "|") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)',
+          message: 'One doc tagged|{count} docs tagged',
+        },
+        {count},
+      ),
+    );
+}
+function DocItem({doc}) {
+  return (
+    <article className="margin-vert--lg">
+      <Link to={doc.permalink}>
+        <h2>{doc.title}</h2>
+      </Link>
+      {doc.description && <p>{doc.description}</p>}
+    </article>
+  );
+}
+export default function DocTagDocListPage({tag}) {
+  const nDocsTaggedPlural = useNDocsTaggedPlural();
+  const title = translate(
+    {
+      id: 'theme.docs.tagDocListPageTitle',
+      description: 'The title of the page for a docs tag',
+      message: '{nDocsTagged} with "{tagName}"',
+    },
+    {nDocsTagged: nDocsTaggedPlural(tag.count), tagName: tag.label},
+  );
+  return (
+    <HtmlClassNameProvider
+      className={clsx(
+        ThemeClassNames.wrapper.docsPages,
+        ThemeClassNames.page.docsTagDocListPage,
+      )}>
+      <PageMetadata title={title}>
+        <meta name="robots" content="noindex, nofollow" />
+      </PageMetadata>
+      <SearchMetadata tag="doc_tag_doc_list" />
+      <Layout>
+        <div className="container margin-vert--lg">
+          <div className="row">
+            <main className="col col--8 col--offset-2">
+              <header className="margin-bottom--xl">
+                <h1>{title}</h1>
+                <Link href={tag.allTagsPath}>
+                  <Translate
+                    id="theme.tags.tagsPageLink"
+                    description="The label of the link targeting the tag list page">
+                    View All Tags
+                  </Translate>
+                </Link>
+              </header>
+              <section className="margin-vert--lg">
+                {tag.items.map((doc) => (
+                  <DocItem key={doc.id} doc={doc} />
+                ))}
+              </section>
+            </main>
+          </div>
+        </div>
+      </Layout>
+    </HtmlClassNameProvider>
+  );
+}

--- a/knowledge-base/src/theme/DocTagsListPage/index.js
+++ b/knowledge-base/src/theme/DocTagsListPage/index.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import clsx from 'clsx';
+import {
+  PageMetadata,
+  HtmlClassNameProvider,
+  ThemeClassNames,
+  translateTagsPageTitle,
+} from '@docusaurus/theme-common';
+import Layout from '@theme/Layout';
+import TagsListByLetter from '@theme/TagsListByLetter';
+import SearchMetadata from '@theme/SearchMetadata';
+export default function DocTagsListPage({tags}) {
+  const title = translateTagsPageTitle();
+  return (
+    <HtmlClassNameProvider
+      className={clsx(
+        ThemeClassNames.wrapper.docsPages,
+        ThemeClassNames.page.docsTagsListPage,
+      )}>
+      <PageMetadata title={title}>
+        <meta name="robots" content="noindex, nofollow" />
+      </PageMetadata>
+      <SearchMetadata tag="doc_tags_list" />
+      <Layout>
+        <div className="container margin-vert--lg">
+          <div className="row">
+            <main className="col col--8 col--offset-2">
+              <h1>{title}</h1>
+              <TagsListByLetter tags={tags} />
+            </main>
+          </div>
+        </div>
+      </Layout>
+    </HtmlClassNameProvider>
+  );
+}


### PR DESCRIPTION
Auto-generated pages for tags and categories doesn't have a meta description tag and they also have a low text-HTML ratio.

This affects negatively to our SEO performance so I've added a meta tag for these pages to prevent them to be indexed by search engine crawlers.

I've had to eject some components from the current theme to be able to apply this change because, right now, there's no other way to do it.

To test this change you can visit these pages and review that the meta tag `<meta data-rh="true" name="robots" content="noindex, nofollow">` is present.

- https://clickhouse-knowledge-base-knowledge-base-wr-git-186176-tinybird.vercel.app/category/clickhouse-fundamentals
- https://clickhouse-knowledge-base-knowledge-base-wr-git-186176-tinybird.vercel.app/tags/beginner
- https://clickhouse-knowledge-base-knowledge-base-wr-git-186176-tinybird.vercel.app/tags

<img width="666" alt="image" src="https://user-images.githubusercontent.com/3751801/200639429-a218d66f-49f9-4d18-b0e6-d9735e18fa1b.png">

Note that links and styles in these pages don't work as expected because we are using a specific configuration to serve this site under /clickhouse/knowledge-base.