### PR TITLE
Fix homepage alternate links

### DIFF
--- a/knowledge-base/docs/intro.mdx
+++ b/knowledge-base/docs/intro.mdx
@@ -6,6 +6,10 @@ description: Looking for ClickHouse info? Check out this ClickHouse knowledge ba
 keywords: [clickhouse, docs, guides, knowledge base]
 ---
 
+<head>
+  <link rel="alternate" href="https://www.tinybird.co/clickhouse/knowledge-base/" hrefLang="en" />
+  <link rel="alternate" href="https://www.tinybird.co/clickhouse/knowledge-base/" hrefLang="x-default" />
+</head>
 
 # Introduction
 


### PR DESCRIPTION
Right now we're serving `alternate` links that comes with the pathname duplicated causing SEO errors and errors also in browser behaviour.

This only happens in the homepage and it's caused by the combination of our proxy pass and the docusaurus configuration we're using. I've tried different ways to fix this but it seems that there's no way to do it right now without adding some custom code to the intro page.

I've applied some specific meta tags in the intro page to override the default ones as a temporary fix in this commit.