### PR TITLE
Remove trailing slash on index page hreflangs

### DIFF
--- a/knowledge-base/docs/intro.mdx
+++ b/knowledge-base/docs/intro.mdx
@@ -7,8 +7,8 @@ keywords: [clickhouse, docs, guides, knowledge base]
 ---
 
 <head>
-  <link rel="alternate" href="https://www.tinybird.co/clickhouse/knowledge-base/" hrefLang="en" />
-  <link rel="alternate" href="https://www.tinybird.co/clickhouse/knowledge-base/" hrefLang="x-default" />
+  <link rel="alternate" href="https://www.tinybird.co/clickhouse/knowledge-base" hrefLang="en" />
+  <link rel="alternate" href="https://www.tinybird.co/clickhouse/knowledge-base" hrefLang="x-default" />
 </head>
 
 # Introduction


### PR DESCRIPTION
We aren't using trailing slash for pathnames in our urls but I added them when I included the hreflangs meta-tags for the index in https://github.com/tinybirdco/clickhouse_knowledge_base/pull/27.

This commit removes them to prevent errors.