### PR TITLE
Semrush fix: Remove duplicate alternate hreflang links

### DIFF
--- a/knowledge-base/docs/intro.mdx
+++ b/knowledge-base/docs/intro.mdx
@@ -6,11 +6,6 @@ description: Looking for ClickHouse info? Check out this ClickHouse knowledge ba
 keywords: [clickhouse, docs, guides, knowledge base]
 ---
 
-<head>
-  <link rel="alternate" href="https://www.tinybird.co/clickhouse/knowledge-base" hrefLang="en" />
-  <link rel="alternate" href="https://www.tinybird.co/clickhouse/knowledge-base" hrefLang="x-default" />
-</head>
-
 # Introduction
 
 Welcome to the ClickHouse® Knowledge Base, curated with love by [Tinybird](https://www.tinybird.co)!


### PR DESCRIPTION
We are explicitly declaring two hreflang links
The expected behavior would be for Docusaurus to just print ours.
But it doesn't seem to be smart enough and duplicates these alternate links with the built-in ones.

So let's remove this one and fix the issue

Related links:
- [SemRush audit](https://www.semrush.com/siteaudit/campaign/8307922/review/#issue/detail/24)